### PR TITLE
Check if at location previously without using Overpass

### DIFF
--- a/app/src/androidTest/java/com/teester/whatsnearby/DatabaseInstrumentedTest.java
+++ b/app/src/androidTest/java/com/teester/whatsnearby/DatabaseInstrumentedTest.java
@@ -92,4 +92,28 @@ public class DatabaseInstrumentedTest {
 		visitedLocationDao.delete(visitedLocationDao.findByOsmId(osmObject2.getId()));
 		assertNull(visitedLocationDao.findByOsmId(osmObject2.getId()));
 	}
+
+	@Test
+	public void onFindByLocationCheckLocationFound() {
+		visitedLocationDao.insert(new VisitedLocation(osmObject));
+		visitedLocationDao.insert(new VisitedLocation(osmObject2));
+		visitedLocationDao.insert(new VisitedLocation(osmObject3));
+		visitedLocationDao.insert(new VisitedLocation(osmObject4));
+		visitedLocationDao.insert(new VisitedLocation(osmObject5));
+
+		List<VisitedLocation> list = visitedLocationDao.findByLocation(1, 1);
+		assertEquals(5, list.size());
+	}
+
+	@Test
+	public void onFindByLocationCheckLocationNotFound() {
+		visitedLocationDao.insert(new VisitedLocation(osmObject));
+		visitedLocationDao.insert(new VisitedLocation(osmObject2));
+		visitedLocationDao.insert(new VisitedLocation(osmObject3));
+		visitedLocationDao.insert(new VisitedLocation(osmObject4));
+		visitedLocationDao.insert(new VisitedLocation(osmObject5));
+
+		List<VisitedLocation> list = visitedLocationDao.findByLocation(10, 10);
+		assertEquals(0, list.size());
+	}
 }

--- a/app/src/main/java/com/teester/whatsnearby/data/database/VisitedLocationDao.java
+++ b/app/src/main/java/com/teester/whatsnearby/data/database/VisitedLocationDao.java
@@ -25,4 +25,9 @@ public interface VisitedLocationDao {
 
 	@Update
 	void update(VisitedLocation visitedLocation);
+
+	@Query("select * from VisitedLocation " +
+			"where latitude between (:latitude-0.01) and (:latitude+0.01) " +
+			"and longitude between (:longitude-0.01) and (:longitude+0.01)")
+	List<VisitedLocation> findByLocation(double latitude, double longitude);
 }

--- a/app/src/main/java/com/teester/whatsnearby/data/location/LocationJobPresenter.java
+++ b/app/src/main/java/com/teester/whatsnearby/data/location/LocationJobPresenter.java
@@ -164,7 +164,7 @@ public class LocationJobPresenter
 		}
 
 		if (query) {
-			notQueryReason += "• Queried";
+			notQueryReason += "• Queried\n";
 		}
 
 		preferences.setStringPreference(PreferenceList.NOT_QUERY_REASON, notQueryReason);


### PR DESCRIPTION
Fixed #16: When location is checked, we compare the distance from the current location to nearby POIs stored in the database.  If they are within 20m of a location that they've been to in the past week, we don't query Overpass.