### PR TITLE
Change text on logging in to reflect if username is available

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'android.arch.lifecycle:extensions:1.1.1'
     implementation 'android.arch.persistence.room:runtime:1.1.1'
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'

--- a/app/src/main/java/com/teester/whatsnearby/main/MainActivityPresenter.java
+++ b/app/src/main/java/com/teester/whatsnearby/main/MainActivityPresenter.java
@@ -36,7 +36,7 @@ public class MainActivityPresenter implements MainActivityContract.Presenter {
 		int button;
 		String userName = getUserName();
 		if (loggedIn) {
-			if (userName == "") {
+            if ("".equals(userName)) {
 				message = R.string.logged_in;
 			} else {
 				message = R.string.logged_in_as;

--- a/app/src/main/java/com/teester/whatsnearby/main/MainActivityPresenter.java
+++ b/app/src/main/java/com/teester/whatsnearby/main/MainActivityPresenter.java
@@ -36,7 +36,11 @@ public class MainActivityPresenter implements MainActivityContract.Presenter {
 		int button;
 		String userName = getUserName();
 		if (loggedIn) {
-			message = R.string.logged_in_as;
+			if (userName == "") {
+				message = R.string.logged_in;
+			} else {
+				message = R.string.logged_in_as;
+			}
 			button = R.string.log_out;
 		} else {
 			message = R.string.not_logged_in;

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -41,6 +41,7 @@
     <string name="check_pois_instruction">Klicken Sie auf die Schaltfläche unten, um nach interessanten Orten in der Nähe Ihres aktuellen Standorts zu suchen.</string>
     <string name="check_now_button">Jetzt prüfen!</string>
     <string name="logged_in_as">Sie sind derzeit bei OpenStreetMap als %s angemeldet.\nWhat\'s Nearby? benachrichtigt Sie, wenn Sie sich an einem Ort befinden, an dem Informationen in OpenStreetMap fehlen.</string>
+    <string name="logged_in">Sie sind derzeit bei OpenStreetMap angemeldet.\nWhat\'s Nearby? benachrichtigt Sie, wenn Sie sich an einem Ort befinden, an dem Informationen in OpenStreetMap fehlen.</string>
     <string name="log_out">Ausloggen</string>
     <string name="changeset_comment">Details zu %s hinzugefügt</string>
     <string name="close">Schließen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,7 +33,7 @@
     <string name="organic">Est-ce que %s vend des produits biologiques?</string>
     <string name="upload_thanks">Merci de répondre. Vos réponses ont contribué à améliorer OpenStreetmap pour tout le monde</string>
     <string name="authorise_openstreetmap">Autoriser OpenStreetmap</string>
-    <string name="not_logged_in">Vous n\'êtes pas connecté à OpenStreetmap. Vos réponses ne peuvent être téléchargées tant que vous n\'êtes pas connecté. Veuillez cliquer sur le bouton ci-dessous pour vous connecter ou créer un compte avec OpenStreetMap</string>
+    <string name="not_logged_in">Vous n‘êtes pas connecté à OpenStreetmap. Vos réponses ne peuvent être téléchargées tant que vous n’êtes pas connecté. Veuillez cliquer sur le bouton ci-dessous pour vous connecter ou créer un compte avec OpenStreetMap</string>
     <string name="osm_login_description">Avant de pouvoir répondre à vos questions, vous devez vous connecter à votre compte OpenStreetMap.</string>
     <string name="osm_login_button">Se connecter à OpenStreetMap</string>
     <string name="select_current_location">Pas à %s?\\nSélectionnez l\'endroit où vous vous trouvez actuellement</string>
@@ -41,6 +41,7 @@
     <string name="check_pois_instruction">Cliquez sur le bouton ci-dessous pour vérifier les points d\'intérêt autour de votre position actuelle.</string>
     <string name="check_now_button">Vérifie maintenant!</string>
     <string name="logged_in_as">Vous êtes actuellement connecté à OpenStreetMap en tant que %s.\nWhat\'s Nearby? vous avertira lorsque vous vous trouvez dans un endroit où des informations sont manquantes dans OpenStreetMap.</string>
+    <string name="logged_in">Vous êtes actuellement connecté à OpenStreetMap.\nWhat\'s Nearby? vous avertira lorsque vous vous trouvez dans un endroit où des informations sont manquantes dans OpenStreetMap.</string>
     <string name="log_out">Connectez - Out</string>
     <string name="close">Fermer</string>
     <string name="changeset_comment">Ajout de détails à %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="check_pois_instruction">Click the button below to check for points of interest around your current location.</string>
     <string name="check_now_button">Check Now!</string>
     <string name="logged_in_as">You are currently logged in to OpenStreetMap as %s.\nWhat\'s Nearby? will notify you when you\'re in a location where there is missing information in OpenStreetMap.</string>
+    <string name="logged_in">You are currently logged in to OpenStreetMap.\nWhat\'s Nearby? will notify you when you\'re in a location where there is missing information in OpenStreetMap.</string>
     <string name="log_out">Log Out</string>
     <string name="changeset_comment">Added details to %s</string>
     <string name="changeset_source" translatable="false">survey</string>


### PR DESCRIPTION
Resolves #41: Username not immediately shown after logging in making the text not make grammatical sense.  There is a slight delay between logging in and when the username is available to the app.  If the username is not available, use an alternative string which does not contain the username.